### PR TITLE
Bumps up the default play services.

### DIFF
--- a/plugin.js
+++ b/plugin.js
@@ -3,7 +3,7 @@
 
 const NPM_MODULE_NAME = 'react-native-maps'
 const NPM_MODULE_VERSION = '0.13.0'
-const PLAY_SERVICES_VERSION = '9.6.1'
+const PLAY_SERVICES_VERSION = '10.2.0'
 // const PLUGIN_PATH = __dirname
 const APP_PATH = process.cwd()
 const EXAMPLE_FILE = 'MapsExample.js'


### PR DESCRIPTION
Looks like they're using some 10.x features in the `0.13.0` of `react-native-maps`.

We'll have to bump our minimum version for this to `10.2.0`.

The downside to this is clients will have to update their Google Play services on their device.  Unless we're willing to remove those 10.x features from react-native-maps (I don't even know where they are), then we're forced into this.