### PR TITLE
Update map-callout-component.js.ejs

### DIFF
--- a/templates/map-callout-component.js.ejs
+++ b/templates/map-callout-component.js.ejs
@@ -1,7 +1,7 @@
 import React from 'react'
 import { Text, TouchableOpacity } from 'react-native'
 import { Callout } from 'react-native-maps'
-import Styles from './Styles/<%= props.calloutName %>CalloutStyles'
+import Styles from './Styles/<%= props.calloutName %>Styles'
 
 export default class <%= props.calloutName %> extends React.Component {
   constructor (props) {


### PR DESCRIPTION
Fixed reference to CalloutStyles from CalloutComponent. Previously the word 'Callout' was duplicated after generation.