### PR TITLE
Fix/react native maps version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ignite-maps",
   "description": "Ignite plugin that adds react-native-maps support.",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "license": "MIT",
   "files": [
     "commands",

--- a/plugin.js
+++ b/plugin.js
@@ -2,7 +2,7 @@
 // ----------------------------------------------------------------------------
 
 const NPM_MODULE_NAME = 'react-native-maps'
-const NPM_MODULE_VERSION = '0.13.0'
+const NPM_MODULE_VERSION = '0.16.4'
 const PLAY_SERVICES_VERSION = '10.2.0'
 // const PLUGIN_PATH = __dirname
 const APP_PATH = process.cwd()


### PR DESCRIPTION
According to https://github.com/airbnb/react-native-maps/issues/1193, the version of react-native-maps we were using wasn't compatible with RN 0.47.2, which we upgraded the boilerplate to in https://github.com/infinitered/ignite-ir-boilerplate/pull/132. 

This should hopefully fix https://github.com/infinitered/ignite-maps/issues/18.

![simulator screen shot sep 21 2017 10 24 02 am](https://user-images.githubusercontent.com/6894653/30710311-fff88748-9eb9-11e7-891f-436eb35c2ea7.png)
